### PR TITLE
Escape backreferences in subpage

### DIFF
--- a/PicoNestedPages.php
+++ b/PicoNestedPages.php
@@ -53,7 +53,7 @@ class PicoNestedPages extends AbstractPicoPlugin
 
           # Now sub it into the original
           $pattern = preg_quote($path, '/');
-          $markdown = preg_replace("/@\[$pattern\]/", $sub, $markdown);
+          $markdown = preg_replace("/@\[$pattern\]/", addcslashes($sub, '\\$'), $markdown);
         }
       }
     }


### PR DESCRIPTION
Make sure strings in markdown text aren't interpreted as backreferences by `preg_replace()`.
See explanations under __replacement__ [here](https://www.php.net/manual/en/function.preg-replace.php) and the usage of `addcslashes()` suggested [here](https://www.php.net/manual/en/function.preg-replace.php#124934).

I noticed this when the string `"$0"` in my markdown subpage was replaced with `"@[path/to/subpage.md]"`.